### PR TITLE
Tiny bug fix on property accessor

### DIFF
--- a/lib/withings-api/api_actions.rb
+++ b/lib/withings-api/api_actions.rb
@@ -126,7 +126,7 @@ module Withings
       end
 
       def access_token(o)
-        @consumer_token || o || raise(StandardError, "No access token")
+        @access_token || o || raise(StandardError, "No access token")
       end
     end
   end


### PR DESCRIPTION
Accessing ApiActions.access_token is undocumented and doesn't seem to be done internally, but still...
